### PR TITLE
Add randomized glitch effect with seed-based reproducibility

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,17 +20,22 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## アーキテクチャ
 
 ```
-api/index.ts          — Vercelサーバーレス関数エントリポイント
-  └─ src/svg.ts       — SVG生成メインロジック (createElement)
-      ├─ src/create.ts — 要素ファクトリ (画像fetch+base64変換 / テキスト要素生成)
-      ├─ src/tag.ts    — HTML/SVGタグ文字列ビルダー
-      └─ src/style.ts  — CSSスタイル/ダークモードメディアクエリ生成
+api/index.ts             — Vercelサーバーレス関数エントリポイント
+  └─ src/svg.ts          — SVG生成メインロジック (createElement)
+      ├─ src/create.ts   — 要素ファクトリ (画像fetch+base64変換 / テキスト要素生成)
+      ├─ src/filter.ts   — SVGフィルタチェーン生成 (createGlitchFilter)
+      ├─ src/random.ts   — シード値ベースのグリッチパラメータ生成
+      ├─ src/schema.ts   — クエリパラメータのバリデーション
+      ├─ src/svg-style.ts — CSSスタイル/ダークモードメディアクエリ生成
+      ├─ src/style.ts    — 汎用スタイルヘルパー
+      └─ src/tag.ts      — HTML/SVGタグ文字列ビルダー
 ```
 
-- `api/index.ts`: クエリパラメータ(`text`, `url`, `width`, `height`, `color`, `darkColor`, `fontSize`)を受け取り、`createElement()`でSVGを生成して返す。2時間キャッシュ設定。
-- `src/svg.ts`: SVGフィルタチェーン(colorMatrix → feOffset → feBlend → feMerge)でグリッチエフェクトを構築。3秒周期のアニメーション。
+- `api/index.ts`: クエリパラメータ(`text`, `url`, `width`, `height`, `color`, `darkColor`, `fontSize`, `seed`)を受け取り、`createElement()`でSVGを生成して返す。2時間キャッシュ設定。
+- `src/svg.ts`: SVGフィルタチェーン(colorMatrix → feOffset → feBlend → feMerge)でグリッチエフェクトを構築。
+- `src/random.ts`: シード値からRNGを生成し、アニメーション周期(2.5〜5.0秒)、チャンネルオフセット、スライス定義をランダム生成。
 - `src/create.ts`: `createImageElement`はaxiosで画像取得→base64変換→image-sizeで寸法取得。`createTextElement`はテキストSVG要素を生成。
-- 型定義は `src/@types/Query.d.ts` にクエリパラメータの型がある。
+- 型定義は `src/schema.ts` でvalibotスキーマとして定義。
 
 ## デプロイ
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
   <h3>
-    <img width="400" alt="glitch-image" src="https://glitch-image.vercel.app/api">
+    <img width="400" alt="glitch-image" src="https://glitch-image.vercel.app/api?seed=429636">
   </h3>
   <p align="center">Copy-paste this into your markdown content, and that's it. Simple!</p>
 </div>
@@ -15,15 +15,27 @@ Change the `?text=` value to your want to glitch text.
 
 ### Image
 
-Change the `?url=` value to your want to glitch image url.  
-※ Not supported files other than `.png`.
+Change the `?url=` value to your want to glitch image url.
 
 ```md
 [![badge](https://glitch-image.vercel.app/api?url=https://github.com/ivgtr.png)](https://glitch-image.vercel.app/api?url=https://github.com/ivgtr.png)
 ```
 
+## Parameters
+
+| Parameter | Description | Default | Example |
+|-----------|-------------|---------|---------|
+| `text` | Glitch text (1-200 chars) | `Glitch Image` | `?text=Hello` |
+| `url` | Image URL to glitch | - | `?url=https://example.com/img.png` |
+| `width` | SVG width (1-4096) | auto | `?width=600` |
+| `height` | SVG height (1-4096) | auto | `?height=400` |
+| `color` | Text color (hex, without `#`) | `3f3f3f` | `?color=ff0000` |
+| `darkColor` | Text color for dark mode (hex, without `#`) | `f3f3f3` | `?darkColor=cccccc` |
+| `fontSize` | Font size (1-500) | `10` | `?fontSize=48` |
+| `seed` | Seed for glitch pattern (0-2147483647) | time-based | `?seed=429636` |
+
 ## License
 
 MIT ©[ivgtr](https://github.com/ivgtr)
 
-[![Twitter Follow](https://img.shields.io/twitter/follow/ivgtr?style=social)](https://twitter.com/ivgtr) [![MIT License](http://img.shields.io/badge/license-MIT-blue.svg?style=flat)](LICENSE) [![Donate](https://img.shields.io/badge/%EF%BC%84-support-green.svg?style=flat-square)](https://www.buymeacoffee.com/ivgtr)
+[![Twitter Follow](https://img.shields.io/twitter/follow/ivgtr?style=social)](https://twitter.com/ivgtr) [![MIT License](http://img.shields.io/badge/license-MIT-blue.svg?style=flat)](LICENSE)

--- a/api/index.ts
+++ b/api/index.ts
@@ -7,10 +7,17 @@ import { createElement } from '../src/svg.js'
 
 const CACHE_MAX_AGE = 60 * 60 * 2
 
+const SEED_INTERVAL_SECONDS = CACHE_MAX_AGE
+
+function computeTimeSeed(): number {
+  return Math.floor(Math.floor(Date.now() / 1000) / SEED_INTERVAL_SECONDS)
+}
+
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   try {
     const query = validateQuery(req.query as QueryInput)
-    const svg = await createElement(query)
+    const seed = query.seed ?? computeTimeSeed()
+    const svg = await createElement({ ...query, seed })
 
     res.writeHead(200, {
       'Content-Type': 'image/svg+xml',

--- a/api/index.ts
+++ b/api/index.ts
@@ -40,6 +40,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       return
     }
 
+    console.error('Unhandled error:', error)
     res.status(500).json({
       error: 'Internal Server Error'
     })

--- a/src/create.ts
+++ b/src/create.ts
@@ -10,10 +10,7 @@ export interface ElementResult {
 }
 
 function escapeTextContent(text: string): string {
-  return text
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
+  return text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
 }
 
 export async function createImageElement(url: string): Promise<ElementResult> {
@@ -24,12 +21,13 @@ export async function createImageElement(url: string): Promise<ElementResult> {
     maxRedirects: 3
   })
 
-  const buffer = Buffer.from(response.data, 'binary').toString('base64')
+  const contentType = (response.headers['content-type'] as string) ?? 'image/jpeg'
+  const buffer = Buffer.from(response.data).toString('base64')
   const dimensions = imageSize(new Uint8Array(response.data))
 
   return {
     content: tag('image', {
-      href: `data:image/jpeg;base64,${buffer}`,
+      href: `data:${contentType};base64,${buffer}`,
       filter: 'url(#glitch)',
       x: '5%',
       y: '5%',

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -1,4 +1,15 @@
+import type { GlitchParams } from './random.js'
 import tag from './tag.js'
+
+export interface SliceDefinition {
+  y: string
+  height: string
+  result: string
+  animation?: {
+    values: string
+    keyTimes: string
+  }
+}
 
 function createColorMatrices(): string {
   return [
@@ -23,17 +34,17 @@ function createColorMatrices(): string {
   ].join('')
 }
 
-function createChannelOffsets(): string {
+function createChannelOffsets(params: GlitchParams): string {
   return [
     tag(
       'feOffset',
       { in: 'red', result: 'red-shifted', dx: '-0.05', dy: '0' },
       tag('animate', {
         attributeName: 'dx',
-        values: '0; -0.05; 0; -0.07; -0.07',
-        keyTimes: '0; 0.3; 0.33; 0.7; 0.75',
+        values: params.channelOffsets.red.values,
+        keyTimes: params.channelOffsets.red.keyTimes,
         begin: '0s',
-        dur: '3s',
+        dur: params.duration,
         calcMode: 'discrete',
         repeatCount: 'indefinite',
         fill: 'freeze'
@@ -44,10 +55,10 @@ function createChannelOffsets(): string {
       { in: 'blue', result: 'blue-shifted', dx: '0.05', dy: '0' },
       tag('animate', {
         attributeName: 'dx',
-        values: '0; 0.05; 0; 0.07; 0.07',
-        keyTimes: '0; 0.3; 0.33; 0.7; 0.75',
+        values: params.channelOffsets.blue.values,
+        keyTimes: params.channelOffsets.blue.keyTimes,
         begin: '0s',
-        dur: '3s',
+        dur: params.duration,
         calcMode: 'discrete',
         repeatCount: 'indefinite',
         fill: 'freeze'
@@ -63,85 +74,49 @@ function createBlendOperations(): string {
   ].join('')
 }
 
-interface SliceDefinition {
-  y: string
-  height: string
-  result: string
-  animation?: {
-    values: string
-    keyTimes: string
-  }
+function createGlitchSlices(params: GlitchParams): string {
+  return params.slices
+    .map((slice) => {
+      const attrs = {
+        in: 'blended',
+        dx: '0',
+        dy: '0',
+        y: slice.y,
+        height: slice.height,
+        result: slice.result
+      }
+
+      if (slice.animation) {
+        return tag(
+          'feOffset',
+          attrs,
+          tag('animate', {
+            attributeName: 'dx',
+            values: slice.animation.values,
+            keyTimes: slice.animation.keyTimes,
+            begin: '0s',
+            dur: params.duration,
+            calcMode: 'discrete',
+            repeatCount: 'indefinite',
+            fill: 'freeze'
+          })
+        )
+      }
+
+      return tag('feOffset', attrs)
+    })
+    .join('')
 }
 
-const SLICES: SliceDefinition[] = [
-  { y: '0%', height: '30%', result: 'slice1' },
-  {
-    y: '30%',
-    height: '10%',
-    result: 'slice2',
-    animation: { values: '0; -0.05; 0; -0.1', keyTimes: '0; 0.3; 0.33; 0.7' }
-  },
-  { y: '40%', height: '10%', result: 'slice3' },
-  {
-    y: '50%',
-    height: '2%',
-    result: 'slice4',
-    animation: { values: '0; 0.1; 0; 0.1; 0.2', keyTimes: '0; 0.3; 0.33; 0.7; 0.75' }
-  },
-  { y: '52%', height: '12%', result: 'slice5' },
-  {
-    y: '64%',
-    height: '3%',
-    result: 'slice6',
-    animation: {
-      values: '0; -0.05; 0; -0.01; -0.15; -0.1; -0.15; -0.1; -0.15',
-      keyTimes: '0; 0.3; 0.33; 0.8; 0.82; 0.84; 0.86; 0.88; 0.9'
-    }
-  },
-  { y: '67%', height: '33%', result: 'slice7' }
-]
-
-function createGlitchSlices(): string {
-  return SLICES.map((slice) => {
-    const attrs = {
-      in: 'blended',
-      dx: '0',
-      dy: '0',
-      y: slice.y,
-      height: slice.height,
-      result: slice.result
-    }
-
-    if (slice.animation) {
-      return tag(
-        'feOffset',
-        attrs,
-        tag('animate', {
-          attributeName: 'dx',
-          values: slice.animation.values,
-          keyTimes: slice.animation.keyTimes,
-          begin: '0s',
-          dur: '3s',
-          calcMode: 'discrete',
-          repeatCount: 'indefinite',
-          fill: 'freeze'
-        })
-      )
-    }
-
-    return tag('feOffset', attrs)
-  }).join('')
-}
-
-function createMergeNode(): string {
+function createMergeNode(params: GlitchParams): string {
   return tag(
     'feMerge',
     {},
-    ...SLICES.map((slice) => tag('feMergeNode', { in: slice.result }))
+    ...params.slices.map((slice) => tag('feMergeNode', { in: slice.result }))
   )
 }
 
-export function createGlitchFilter(): string {
+export function createGlitchFilter(params: GlitchParams): string {
   return tag(
     'defs',
     {},
@@ -156,10 +131,10 @@ export function createGlitchFilter(): string {
         height: '120%'
       },
       createColorMatrices(),
-      createChannelOffsets(),
+      createChannelOffsets(params),
       createBlendOperations(),
-      createGlitchSlices(),
-      createMergeNode()
+      createGlitchSlices(params),
+      createMergeNode(params)
     )
   )
 }

--- a/src/random.ts
+++ b/src/random.ts
@@ -9,6 +9,32 @@ export interface GlitchParams {
   slices: SliceDefinition[]
 }
 
+type DelayType = 'FLASH' | 'QUICK' | 'NORMAL' | 'FREEZE'
+
+interface Frame {
+  dx: number
+  delay: DelayType
+}
+
+const DELAY_RATIOS: Record<DelayType, number> = {
+  FLASH: 0.03,
+  QUICK: 0.06,
+  NORMAL: 0.12,
+  FREEZE: 0.25
+} as const
+
+const RHYTHM_PATTERNS: DelayType[][] = [
+  ['NORMAL', 'FLASH', 'QUICK', 'FLASH'],
+  ['FLASH', 'FREEZE', 'FLASH', 'QUICK'],
+  ['FLASH', 'QUICK', 'NORMAL', 'FREEZE'],
+  ['QUICK', 'NORMAL', 'QUICK', 'FLASH'],
+  ['FLASH', 'FLASH', 'FLASH', 'QUICK'],
+  ['FLASH', 'FREEZE', 'FLASH', 'FREEZE'],
+  ['FLASH', 'FLASH', 'QUICK', 'NORMAL']
+]
+
+const PHI = 1.618
+
 function createRng(seed: number): () => number {
   let s = seed | 0
   return () => {
@@ -27,14 +53,86 @@ function randInt(rng: () => number, min: number, max: number): number {
   return Math.floor(lerp(rng, min, max + 1))
 }
 
-function generateKeyTimes(rng: () => number, steps: number): string {
-  const times = [0]
-  for (let i = 1; i < steps - 1; i++) {
-    times.push(rng())
+function selectRhythmPattern(rng: () => number): DelayType[] {
+  return RHYTHM_PATTERNS[randInt(rng, 0, RHYTHM_PATTERNS.length - 1)]
+}
+
+function buildTensionCurve(rng: () => number, steps: number): number[] {
+  const intensities: number[] = []
+  const remaining = steps
+  const buildupCount = Math.max(1, Math.round((remaining * PHI) / (PHI + 1)))
+  const climaxCount = randInt(rng, 1, 2)
+  const releaseCount = Math.max(1, steps - buildupCount - climaxCount)
+  const actualBuildupCount = steps - climaxCount - releaseCount
+
+  for (let i = 0; i < actualBuildupCount; i++) {
+    const t = actualBuildupCount === 1 ? 1 : i / (actualBuildupCount - 1)
+    intensities.push(0.1 + 0.9 * t * t)
   }
-  times.sort((a, b) => a - b)
-  times.push(1)
-  return times.map((t) => t.toFixed(2).replace(/\.?0+$/, '') || '0').join('; ')
+
+  for (let i = 0; i < climaxCount; i++) {
+    intensities.push(lerp(rng, 0.9, 1.0))
+  }
+
+  for (let i = 0; i < releaseCount; i++) {
+    const t = releaseCount === 1 ? 1 : i / (releaseCount - 1)
+    intensities.push(0.6 * (1 - t))
+  }
+
+  return intensities
+}
+
+function buildFrameSequence(
+  rng: () => number,
+  intensities: number[],
+  rhythm: DelayType[],
+  min: number,
+  max: number
+): Frame[] {
+  const frames: Frame[] = [{ dx: 0, delay: 'QUICK' }]
+
+  for (let i = 0; i < intensities.length; i++) {
+    const intensity = intensities[i]
+    const breathChance = intensity > 0.7 ? 0.1 : intensity > 0.3 ? 0.3 : 0.6
+
+    if (rng() < breathChance) {
+      const breathDelay: DelayType = intensity > 0.7 ? 'QUICK' : 'FREEZE'
+      frames.push({ dx: 0, delay: breathDelay })
+    }
+
+    const amplitude = intensity * (max - min)
+    const dx = min + rng() * amplitude * (rng() < 0.5 ? 1 : -1)
+    const delay = rhythm[i % rhythm.length]
+    frames.push({ dx, delay })
+  }
+
+  frames.push({ dx: 0, delay: 'NORMAL' })
+  return frames
+}
+
+function formatValue(v: number): string {
+  return v.toFixed(2).replace(/\.?0+$/, '') || '0'
+}
+
+function framesToValuesAndKeyTimes(frames: Frame[]): { values: string; keyTimes: string } {
+  const totalRatio = frames.reduce((sum, f) => sum + DELAY_RATIOS[f.delay], 0)
+
+  const values: string[] = []
+  const keyTimes: string[] = []
+  let cumulative = 0
+
+  for (let i = 0; i < frames.length; i++) {
+    values.push(formatValue(frames[i].dx))
+    keyTimes.push(formatValue(cumulative))
+    cumulative += DELAY_RATIOS[frames[i].delay] / totalRatio
+  }
+
+  keyTimes[keyTimes.length - 1] = '1'
+
+  return {
+    values: values.join('; '),
+    keyTimes: keyTimes.join('; ')
+  }
 }
 
 function generateChannelValues(
@@ -42,22 +140,21 @@ function generateChannelValues(
   steps: number,
   min: number,
   max: number
-): string {
-  const values = [0]
-  for (let i = 1; i < steps; i++) {
-    const useZero = rng() < 0.3
-    values.push(useZero ? 0 : lerp(rng, min, max))
-  }
-  return values.map((v) => v.toFixed(2).replace(/\.?0+$/, '') || '0').join('; ')
+): { values: string; keyTimes: string } {
+  const rhythm = selectRhythmPattern(rng)
+  const intensities = buildTensionCurve(rng, steps)
+  const frames = buildFrameSequence(rng, intensities, rhythm, min, max)
+  return framesToValuesAndKeyTimes(frames)
 }
 
-function generateSliceValues(rng: () => number, steps: number): string {
-  const values = [0]
-  for (let i = 1; i < steps; i++) {
-    const useZero = rng() < 0.25
-    values.push(useZero ? 0 : lerp(rng, -0.2, 0.2))
-  }
-  return values.map((v) => v.toFixed(2).replace(/\.?0+$/, '') || '0').join('; ')
+function generateSliceValues(
+  rng: () => number,
+  steps: number
+): { values: string; keyTimes: string } {
+  const rhythm = selectRhythmPattern(rng)
+  const intensities = buildTensionCurve(rng, steps)
+  const frames = buildFrameSequence(rng, intensities, rhythm, -0.2, 0.2)
+  return framesToValuesAndKeyTimes(frames)
 }
 
 export function generateGlitchParams(seed: number): GlitchParams {
@@ -65,18 +162,12 @@ export function generateGlitchParams(seed: number): GlitchParams {
 
   const duration = `${lerp(rng, 2, 5).toFixed(1)}s`
 
-  const redSteps = randInt(rng, 3, 6)
-  const blueSteps = randInt(rng, 3, 6)
+  const redSteps = randInt(rng, 5, 10)
+  const blueSteps = randInt(rng, 5, 10)
 
   const channelOffsets = {
-    red: {
-      values: generateChannelValues(rng, redSteps, -0.12, -0.02),
-      keyTimes: generateKeyTimes(rng, redSteps)
-    },
-    blue: {
-      values: generateChannelValues(rng, blueSteps, 0.02, 0.12),
-      keyTimes: generateKeyTimes(rng, blueSteps)
-    }
+    red: generateChannelValues(rng, redSteps, -0.12, -0.02),
+    blue: generateChannelValues(rng, blueSteps, 0.02, 0.12)
   }
 
   const sliceCount = randInt(rng, 5, 9)
@@ -105,11 +196,8 @@ export function generateGlitchParams(seed: number): GlitchParams {
       result: `slice${i + 1}`
     }
     if (animatedIndices.has(i)) {
-      const steps = randInt(rng, 3, 9)
-      slice.animation = {
-        values: generateSliceValues(rng, steps),
-        keyTimes: generateKeyTimes(rng, steps)
-      }
+      const steps = randInt(rng, 5, 12)
+      slice.animation = generateSliceValues(rng, steps)
     }
     yPos += h
     return slice

--- a/src/random.ts
+++ b/src/random.ts
@@ -1,0 +1,119 @@
+import type { SliceDefinition } from './filter.js'
+
+export interface GlitchParams {
+  duration: string
+  channelOffsets: {
+    red: { values: string; keyTimes: string }
+    blue: { values: string; keyTimes: string }
+  }
+  slices: SliceDefinition[]
+}
+
+function createRng(seed: number): () => number {
+  let s = seed | 0
+  return () => {
+    s = (s + 0x6d2b79f5) | 0
+    let t = Math.imul(s ^ (s >>> 15), 1 | s)
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+function lerp(rng: () => number, min: number, max: number): number {
+  return min + rng() * (max - min)
+}
+
+function randInt(rng: () => number, min: number, max: number): number {
+  return Math.floor(lerp(rng, min, max + 1))
+}
+
+function generateKeyTimes(rng: () => number, steps: number): string {
+  const times = [0]
+  for (let i = 1; i < steps - 1; i++) {
+    times.push(rng())
+  }
+  times.sort((a, b) => a - b)
+  times.push(1)
+  return times.map((t) => t.toFixed(2).replace(/\.?0+$/, '') || '0').join('; ')
+}
+
+function generateChannelValues(
+  rng: () => number,
+  steps: number,
+  min: number,
+  max: number
+): string {
+  const values = [0]
+  for (let i = 1; i < steps; i++) {
+    const useZero = rng() < 0.3
+    values.push(useZero ? 0 : lerp(rng, min, max))
+  }
+  return values.map((v) => v.toFixed(2).replace(/\.?0+$/, '') || '0').join('; ')
+}
+
+function generateSliceValues(rng: () => number, steps: number): string {
+  const values = [0]
+  for (let i = 1; i < steps; i++) {
+    const useZero = rng() < 0.25
+    values.push(useZero ? 0 : lerp(rng, -0.2, 0.2))
+  }
+  return values.map((v) => v.toFixed(2).replace(/\.?0+$/, '') || '0').join('; ')
+}
+
+export function generateGlitchParams(seed: number): GlitchParams {
+  const rng = createRng(seed)
+
+  const duration = `${lerp(rng, 2, 5).toFixed(1)}s`
+
+  const redSteps = randInt(rng, 3, 6)
+  const blueSteps = randInt(rng, 3, 6)
+
+  const channelOffsets = {
+    red: {
+      values: generateChannelValues(rng, redSteps, -0.12, -0.02),
+      keyTimes: generateKeyTimes(rng, redSteps)
+    },
+    blue: {
+      values: generateChannelValues(rng, blueSteps, 0.02, 0.12),
+      keyTimes: generateKeyTimes(rng, blueSteps)
+    }
+  }
+
+  const sliceCount = randInt(rng, 5, 9)
+  const animatedCount = randInt(rng, 1, Math.ceil(sliceCount / 2))
+
+  const heights: number[] = []
+  let remaining = 100
+  for (let i = 0; i < sliceCount - 1; i++) {
+    const maxH = remaining - (sliceCount - 1 - i)
+    const h = Math.max(1, randInt(rng, 1, Math.max(1, Math.floor(maxH / 2))))
+    heights.push(h)
+    remaining -= h
+  }
+  heights.push(remaining)
+
+  const animatedIndices = new Set<number>()
+  while (animatedIndices.size < animatedCount) {
+    animatedIndices.add(randInt(rng, 0, sliceCount - 1))
+  }
+
+  let yPos = 0
+  const slices: SliceDefinition[] = heights.map((h, i) => {
+    const slice: SliceDefinition = {
+      y: `${yPos}%`,
+      height: `${h}%`,
+      result: `slice${i + 1}`
+    }
+    if (animatedIndices.has(i)) {
+      const steps = randInt(rng, 3, 9)
+      slice.animation = {
+        values: generateSliceValues(rng, steps),
+        keyTimes: generateKeyTimes(rng, steps)
+      }
+    }
+    yPos += h
+    return slice
+  })
+
+  return { duration, channelOffsets, slices }
+}

--- a/src/random.ts
+++ b/src/random.ts
@@ -9,31 +9,25 @@ export interface GlitchParams {
   slices: SliceDefinition[]
 }
 
-type DelayType = 'FLASH' | 'QUICK' | 'NORMAL' | 'FREEZE'
-
-interface Frame {
-  dx: number
-  delay: DelayType
+interface PhaseConfig {
+  rest1: number
+  spark: number
+  rest2: number
+  climax: number
+  sustain: number
 }
 
-const DELAY_RATIOS: Record<DelayType, number> = {
-  FLASH: 0.03,
-  QUICK: 0.06,
-  NORMAL: 0.12,
-  FREEZE: 0.25
-} as const
+interface GlitchProfile {
+  channelRange: number
+  sliceRange: number
+  duration: number
+  climaxFrameCount: number
+}
 
-const RHYTHM_PATTERNS: DelayType[][] = [
-  ['NORMAL', 'FLASH', 'QUICK', 'FLASH'],
-  ['FLASH', 'FREEZE', 'FLASH', 'QUICK'],
-  ['FLASH', 'QUICK', 'NORMAL', 'FREEZE'],
-  ['QUICK', 'NORMAL', 'QUICK', 'FLASH'],
-  ['FLASH', 'FLASH', 'FLASH', 'QUICK'],
-  ['FLASH', 'FREEZE', 'FLASH', 'FREEZE'],
-  ['FLASH', 'FLASH', 'QUICK', 'NORMAL']
-]
-
-const PHI = 1.618
+interface PhaseFrame {
+  dx: number
+  time: number
+}
 
 function createRng(seed: number): () => number {
   let s = seed | 0
@@ -53,60 +47,64 @@ function randInt(rng: () => number, min: number, max: number): number {
   return Math.floor(lerp(rng, min, max + 1))
 }
 
-function selectRhythmPattern(rng: () => number): DelayType[] {
-  return RHYTHM_PATTERNS[randInt(rng, 0, RHYTHM_PATTERNS.length - 1)]
+function generateProfile(rng: () => number): GlitchProfile {
+  return {
+    channelRange: lerp(rng, 0.03, 0.07),
+    sliceRange: lerp(rng, 0.08, 0.2),
+    duration: lerp(rng, 2.5, 5.0),
+    climaxFrameCount: randInt(rng, 3, 8)
+  }
 }
 
-function buildTensionCurve(rng: () => number, steps: number): number[] {
-  const intensities: number[] = []
-  const remaining = steps
-  const buildupCount = Math.max(1, Math.round((remaining * PHI) / (PHI + 1)))
-  const climaxCount = randInt(rng, 1, 2)
-  const releaseCount = Math.max(1, steps - buildupCount - climaxCount)
-  const actualBuildupCount = steps - climaxCount - releaseCount
+function generatePhaseConfig(rng: () => number): PhaseConfig {
+  const rest1 = lerp(rng, 0.2, 0.35)
+  const spark = lerp(rng, 0.02, 0.05)
+  const rest2 = lerp(rng, 0.25, 0.4)
+  const climax = lerp(rng, 0.1, 0.25)
+  const sustain = lerp(rng, 0.05, 0.15)
 
-  for (let i = 0; i < actualBuildupCount; i++) {
-    const t = actualBuildupCount === 1 ? 1 : i / (actualBuildupCount - 1)
-    intensities.push(0.1 + 0.9 * t * t)
+  const total = rest1 + spark + rest2 + climax + sustain
+  return {
+    rest1: rest1 / total,
+    spark: spark / total,
+    rest2: rest2 / total,
+    climax: climax / total,
+    sustain: sustain / total
   }
-
-  for (let i = 0; i < climaxCount; i++) {
-    intensities.push(lerp(rng, 0.9, 1.0))
-  }
-
-  for (let i = 0; i < releaseCount; i++) {
-    const t = releaseCount === 1 ? 1 : i / (releaseCount - 1)
-    intensities.push(0.6 * (1 - t))
-  }
-
-  return intensities
 }
 
-function buildFrameSequence(
+function buildPhaseFrames(
   rng: () => number,
-  intensities: number[],
-  rhythm: DelayType[],
-  min: number,
-  max: number
-): Frame[] {
-  const frames: Frame[] = [{ dx: 0, delay: 'QUICK' }]
+  maxDx: number,
+  climaxFrameCount: number
+): PhaseFrame[] {
+  const phase = generatePhaseConfig(rng)
+  const frames: PhaseFrame[] = []
 
-  for (let i = 0; i < intensities.length; i++) {
-    const intensity = intensities[i]
-    const breathChance = intensity > 0.7 ? 0.1 : intensity > 0.3 ? 0.3 : 0.6
+  // REST1: 静止
+  frames.push({ dx: 0, time: 0 })
 
-    if (rng() < breathChance) {
-      const breathDelay: DelayType = intensity > 0.7 ? 'QUICK' : 'FREEZE'
-      frames.push({ dx: 0, delay: breathDelay })
-    }
+  // SPARK: 一瞬のグリッチ + リセット
+  const sparkDx = lerp(rng, 0.5, 1.0) * maxDx * (rng() < 0.5 ? 1 : -1)
+  frames.push({ dx: sparkDx, time: phase.rest1 })
+  frames.push({ dx: 0, time: phase.rest1 + phase.spark * 0.5 })
 
-    const amplitude = intensity * (max - min)
-    const dx = min + rng() * amplitude * (rng() < 0.5 ? 1 : -1)
-    const delay = rhythm[i % rhythm.length]
-    frames.push({ dx, delay })
+  // REST2: 再び静止（sparkリセット位置からclimaxまで自動的に静止）
+
+  // CLIMAX: 高密度のグリッチフレーム
+  const climaxStart = phase.rest1 + phase.spark + phase.rest2
+  const climaxStepSize = phase.climax / climaxFrameCount
+  for (let i = 0; i < climaxFrameCount; i++) {
+    const intensity = lerp(rng, 0.6, 1.0)
+    const dx = intensity * maxDx * (rng() < 0.5 ? 1 : -1)
+    frames.push({ dx, time: climaxStart + i * climaxStepSize })
   }
 
-  frames.push({ dx: 0, delay: 'NORMAL' })
+  // SUSTAIN: 最後のCLIMAXフレームの値を保持
+  const lastClimaxDx = frames[frames.length - 1].dx
+  frames.push({ dx: lastClimaxDx, time: climaxStart + phase.climax })
+  frames.push({ dx: 0, time: 1 })
+
   return frames
 }
 
@@ -114,94 +112,102 @@ function formatValue(v: number): string {
   return v.toFixed(2).replace(/\.?0+$/, '') || '0'
 }
 
-function framesToValuesAndKeyTimes(frames: Frame[]): { values: string; keyTimes: string } {
-  const totalRatio = frames.reduce((sum, f) => sum + DELAY_RATIOS[f.delay], 0)
+function framesToValuesAndKeyTimes(frames: PhaseFrame[]): {
+  values: string
+  keyTimes: string
+} {
+  const values = frames.map((f) => formatValue(f.dx)).join('; ')
+  const keyTimes = frames.map((f) => formatValue(f.time)).join('; ')
+  return { values, keyTimes }
+}
 
-  const values: string[] = []
-  const keyTimes: string[] = []
-  let cumulative = 0
+function generateSymmetricChannels(
+  rng: () => number,
+  channelRange: number,
+  climaxFrameCount: number
+): {
+  red: { values: string; keyTimes: string }
+  blue: { values: string; keyTimes: string }
+} {
+  const baseFrames = buildPhaseFrames(rng, channelRange, climaxFrameCount)
 
-  for (let i = 0; i < frames.length; i++) {
-    values.push(formatValue(frames[i].dx))
-    keyTimes.push(formatValue(cumulative))
-    cumulative += DELAY_RATIOS[frames[i].delay] / totalRatio
-  }
+  const redFrames = baseFrames.map((f) => {
+    const wobble = f.dx !== 0 ? lerp(rng, 0.8, 1.2) : 1
+    return { dx: -Math.abs(f.dx) * wobble, time: f.time }
+  })
 
-  keyTimes[keyTimes.length - 1] = '1'
+  const blueFrames = baseFrames.map((f) => {
+    const wobble = f.dx !== 0 ? lerp(rng, 0.8, 1.2) : 1
+    return { dx: Math.abs(f.dx) * wobble, time: f.time }
+  })
 
   return {
-    values: values.join('; '),
-    keyTimes: keyTimes.join('; ')
+    red: framesToValuesAndKeyTimes(redFrames),
+    blue: framesToValuesAndKeyTimes(blueFrames)
   }
 }
 
-function generateChannelValues(
-  rng: () => number,
-  steps: number,
-  min: number,
-  max: number
-): { values: string; keyTimes: string } {
-  const rhythm = selectRhythmPattern(rng)
-  const intensities = buildTensionCurve(rng, steps)
-  const frames = buildFrameSequence(rng, intensities, rhythm, min, max)
-  return framesToValuesAndKeyTimes(frames)
-}
+function generateSlices(rng: () => number, profile: GlitchProfile): SliceDefinition[] {
+  const sliceCount = randInt(rng, 8, 16)
 
-function generateSliceValues(
-  rng: () => number,
-  steps: number
-): { values: string; keyTimes: string } {
-  const rhythm = selectRhythmPattern(rng)
-  const intensities = buildTensionCurve(rng, steps)
-  const frames = buildFrameSequence(rng, intensities, rhythm, -0.2, 0.2)
-  return framesToValuesAndKeyTimes(frames)
-}
-
-export function generateGlitchParams(seed: number): GlitchParams {
-  const rng = createRng(seed)
-
-  const duration = `${lerp(rng, 2, 5).toFixed(1)}s`
-
-  const redSteps = randInt(rng, 5, 10)
-  const blueSteps = randInt(rng, 5, 10)
-
-  const channelOffsets = {
-    red: generateChannelValues(rng, redSteps, -0.12, -0.02),
-    blue: generateChannelValues(rng, blueSteps, 0.02, 0.12)
+  // 1. ランダムな重みを生成し、100%に正規化
+  const rawWeights: number[] = []
+  for (let i = 0; i < sliceCount; i++) {
+    rawWeights.push(lerp(rng, 0.5, 1.5))
   }
+  const totalWeight = rawWeights.reduce((sum, w) => sum + w, 0)
+  const heights = rawWeights.map((w) => Math.max(3, Math.round((w / totalWeight) * 100)))
 
-  const sliceCount = randInt(rng, 5, 9)
-  const animatedCount = randInt(rng, 1, Math.ceil(sliceCount / 2))
+  // 丸め誤差を最大スライスで吸収
+  const summed = heights.reduce((sum, h) => sum + h, 0)
+  const maxIdx = heights.indexOf(Math.max(...heights))
+  heights[maxIdx] += 100 - summed
 
-  const heights: number[] = []
-  let remaining = 100
-  for (let i = 0; i < sliceCount - 1; i++) {
-    const maxH = remaining - (sliceCount - 1 - i)
-    const h = Math.max(1, randInt(rng, 1, Math.max(1, Math.floor(maxH / 2))))
-    heights.push(h)
-    remaining -= h
-  }
-  heights.push(remaining)
-
+  // 2. アニメーション付きスライスを均等間隔で選択
+  const animatedCount = Math.ceil(sliceCount / 3)
   const animatedIndices = new Set<number>()
-  while (animatedIndices.size < animatedCount) {
-    animatedIndices.add(randInt(rng, 0, sliceCount - 1))
+  const step = Math.floor(sliceCount / animatedCount)
+  const offset = randInt(rng, 0, step - 1)
+  for (let i = 0; i < animatedCount; i++) {
+    animatedIndices.add(Math.min(offset + i * step, sliceCount - 1))
   }
 
+  // 3. heroスライスを決定（アニメ付きの中で最小高さ）
+  const animatedArray = [...animatedIndices]
+  animatedArray.sort((a, b) => heights[a] - heights[b])
+  const heroIndex = animatedArray[0]
+
+  // 4. スライス定義を構築
   let yPos = 0
-  const slices: SliceDefinition[] = heights.map((h, i) => {
+  return heights.map((h, i) => {
     const slice: SliceDefinition = {
       y: `${yPos}%`,
       height: `${h}%`,
       result: `slice${i + 1}`
     }
     if (animatedIndices.has(i)) {
-      const steps = randInt(rng, 5, 12)
-      slice.animation = generateSliceValues(rng, steps)
+      const isHero = i === heroIndex
+      const frameCount = isHero ? Math.max(profile.climaxFrameCount + 2, 7) : randInt(rng, 3, 5)
+      const frames = buildPhaseFrames(rng, profile.sliceRange, frameCount)
+      slice.animation = framesToValuesAndKeyTimes(frames)
     }
     yPos += h
     return slice
   })
+}
+
+// seed 429636: 元の手動パターン（rest1≈0.30, spark≈0.03, rest2≈0.37, climax≈0.20, sustain≈0.10）に近い比率を生成する
+export function generateGlitchParams(seed: number): GlitchParams {
+  const rng = createRng(seed)
+  const profile = generateProfile(rng)
+
+  const duration = `${profile.duration.toFixed(1)}s`
+  const channelOffsets = generateSymmetricChannels(
+    rng,
+    profile.channelRange,
+    profile.climaxFrameCount
+  )
+  const slices = generateSlices(rng, profile)
 
   return { duration, channelOffsets, slices }
 }

--- a/src/random.ts
+++ b/src/random.ts
@@ -29,6 +29,11 @@ interface PhaseFrame {
   time: number
 }
 
+interface DirectionPattern {
+  spark: number
+  climax: number[]
+}
+
 function createRng(seed: number): () => number {
   let s = seed | 0
   return () => {
@@ -73,19 +78,43 @@ function generatePhaseConfig(rng: () => number): PhaseConfig {
   }
 }
 
+function buildDirectionPattern(rng: () => number, maxFrameCount: number): DirectionPattern {
+  const spark = rng() < 0.5 ? 1 : -1
+
+  const climax: number[] = []
+  let dir = rng() < 0.5 ? 1 : -1
+  let runLen = 0
+  let targetRun = randInt(rng, 2, 4)
+
+  for (let i = 0; i < maxFrameCount; i++) {
+    climax.push(dir)
+    runLen++
+    if (runLen >= targetRun) {
+      dir *= -1
+      runLen = 0
+      targetRun = randInt(rng, 2, 4)
+    }
+  }
+
+  return { spark, climax }
+}
+
 function buildPhaseFrames(
   rng: () => number,
   maxDx: number,
-  climaxFrameCount: number
+  climaxFrameCount: number,
+  sharedPhase?: PhaseConfig,
+  sharedPattern?: DirectionPattern
 ): PhaseFrame[] {
-  const phase = generatePhaseConfig(rng)
+  const phase = sharedPhase ?? generatePhaseConfig(rng)
   const frames: PhaseFrame[] = []
 
   // REST1: 静止
   frames.push({ dx: 0, time: 0 })
 
   // SPARK: 一瞬のグリッチ + リセット
-  const sparkDx = lerp(rng, 0.5, 1.0) * maxDx * (rng() < 0.5 ? 1 : -1)
+  const sparkDir = sharedPattern ? sharedPattern.spark : rng() < 0.5 ? 1 : -1
+  const sparkDx = lerp(rng, 0.5, 1.0) * maxDx * sparkDir
   frames.push({ dx: sparkDx, time: phase.rest1 })
   frames.push({ dx: 0, time: phase.rest1 + phase.spark * 0.5 })
 
@@ -96,7 +125,12 @@ function buildPhaseFrames(
   const climaxStepSize = phase.climax / climaxFrameCount
   for (let i = 0; i < climaxFrameCount; i++) {
     const intensity = lerp(rng, 0.6, 1.0)
-    const dx = intensity * maxDx * (rng() < 0.5 ? 1 : -1)
+    const dir = sharedPattern
+      ? sharedPattern.climax[i % sharedPattern.climax.length]
+      : rng() < 0.5
+        ? 1
+        : -1
+    const dx = intensity * maxDx * dir
     frames.push({ dx, time: climaxStart + i * climaxStepSize })
   }
 
@@ -177,7 +211,12 @@ function generateSlices(rng: () => number, profile: GlitchProfile): SliceDefinit
   animatedArray.sort((a, b) => heights[a] - heights[b])
   const heroIndex = animatedArray[0]
 
-  // 4. スライス定義を構築
+  // 4. 全スライスで共有するタイミングと方向パターン
+  const sharedPhase = generatePhaseConfig(rng)
+  const heroFrameCount = Math.max(profile.climaxFrameCount + 2, 7)
+  const sharedPattern = buildDirectionPattern(rng, heroFrameCount)
+
+  // 5. スライス定義を構築
   let yPos = 0
   return heights.map((h, i) => {
     const slice: SliceDefinition = {
@@ -187,8 +226,9 @@ function generateSlices(rng: () => number, profile: GlitchProfile): SliceDefinit
     }
     if (animatedIndices.has(i)) {
       const isHero = i === heroIndex
-      const frameCount = isHero ? Math.max(profile.climaxFrameCount + 2, 7) : randInt(rng, 3, 5)
-      const frames = buildPhaseFrames(rng, profile.sliceRange, frameCount)
+      const frameCount = isHero ? heroFrameCount : randInt(rng, 3, 5)
+      const maxDx = profile.sliceRange * lerp(rng, 0.8, 1.2)
+      const frames = buildPhaseFrames(rng, maxDx, frameCount, sharedPhase, sharedPattern)
       slice.animation = framesToValuesAndKeyTimes(frames)
     }
     yPos += h

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -11,7 +11,8 @@ const isPrivateIP = (hostname: string): boolean => {
     /^\[?::1\]?$/,
     /^\[?fe80:/i,
     /^\[?fc00:/i,
-    /^\[?fd/i
+    /^\[?fd/i,
+    /^\[?::ffff:(127\.|10\.|172\.(1[6-9]|2\d|3[01])\.|192\.168\.|0\.)/i
   ]
   return patterns.some((p) => p.test(hostname))
 }

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -51,6 +51,15 @@ const urlSchema = v.pipe(
   }, 'Must be a public http/https URL')
 )
 
+const seedSchema = v.pipe(
+  v.string(),
+  v.transform(Number),
+  v.number('Must be a valid number'),
+  v.integer('Must be an integer'),
+  v.minValue(0, 'Must be at least 0'),
+  v.maxValue(2147483647, 'Must be at most 2147483647')
+)
+
 const QuerySchema = v.object({
   text: v.optional(v.pipe(v.string(), v.minLength(1), v.maxLength(200))),
   url: v.optional(urlSchema),
@@ -58,7 +67,8 @@ const QuerySchema = v.object({
   height: v.optional(dimension),
   color: v.optional(hexColor),
   darkColor: v.optional(hexColor),
-  fontSize: v.optional(fontSizeSchema)
+  fontSize: v.optional(fontSizeSchema),
+  seed: v.optional(seedSchema)
 })
 
 export type QueryInput = {
@@ -69,6 +79,7 @@ export type QueryInput = {
   color?: string | string[]
   darkColor?: string | string[]
   fontSize?: string | string[]
+  seed?: string | string[]
 }
 
 export type ValidatedQuery = v.InferOutput<typeof QuerySchema>

--- a/src/svg.ts
+++ b/src/svg.ts
@@ -1,6 +1,7 @@
 import type { ValidatedQuery } from './schema.js'
 import { createImageElement, createTextElement } from './create.js'
 import { createGlitchFilter } from './filter.js'
+import { generateGlitchParams } from './random.js'
 import { createSvgStyles } from './svg-style.js'
 import tag from './tag.js'
 
@@ -20,8 +21,9 @@ export async function createElement({
   height,
   color = DEFAULTS.color,
   darkColor = DEFAULTS.darkColor,
-  fontSize = DEFAULTS.fontSize
-}: ValidatedQuery): Promise<string> {
+  fontSize = DEFAULTS.fontSize,
+  seed
+}: ValidatedQuery & { seed: number }): Promise<string> {
   const resolvedText = text ?? DEFAULTS.text
 
   const {
@@ -34,6 +36,8 @@ export async function createElement({
 
   const viewWidth = width ?? offsetWidth
   const viewHeight = height ?? offsetHeight
+
+  const glitchParams = generateGlitchParams(seed)
 
   return tag(
     'svg',
@@ -54,6 +58,6 @@ export async function createElement({
       },
       content
     ),
-    tag('svg', { x: 0, y: 0 }, createGlitchFilter())
+    tag('svg', { x: 0, y: 0 }, createGlitchFilter(glitchParams))
   )
 }


### PR DESCRIPTION
## Summary
- シード値ベースの擬似乱数でグリッチエフェクトをランダム生成する機能を追加
- アニメーション周期、チャンネルオフセット、スライス分割がseedごとに異なるパターンを生成
- seedを指定しない場合は2時間間隔の時間ベースseedを自動適用（キャッシュと同期）
- 画像MIMEタイプの正確な判定、ArrayBuffer変換修正、SSRF保護強化、エラーログ出力を追加
- READMEにパラメータ一覧を追加し、見出し画像に黄金パターン（seed=429636）を設定

## Changes
- `src/random.ts` — シード値ベースRNGとグリッチパラメータ生成ロジックを新規追加
- `src/filter.ts` — ハードコードされたアニメーション値をGlitchParamsからの動的値に置換
- `src/svg.ts` — seed引数を受け取りgenerateGlitchParamsを呼び出すよう変更
- `src/schema.ts` — seedパラメータのバリデーション追加、IPv4マップドIPv6のSSRF保護追加
- `api/index.ts` — 時間ベースseed計算、500エラー時のログ出力を追加
- `src/create.ts` — レスポンスヘッダーからMIMEタイプ取得、Buffer.from修正
- `README.md` — パラメータテーブル追加、見出し画像にseed指定
- `CLAUDE.md` — アーキテクチャ図を更新

## Test plan
- [x] `?text=TEST` でテキストモードの正常動作を確認
- [x] `?url=<PNG画像URL>` でMIMEタイプが正しく設定されることを確認
- [x] `?seed=429636` で固定パターンが再現されることを確認
- [x] seedなしでアクセスし、時間ベースseedで動作することを確認
- [x] `npx tsc --noEmit` で型チェックパス
- [x] `npx eslint . && npx prettier --check .` でリント・フォーマットパス